### PR TITLE
Improve clean and distclean targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -38,10 +38,11 @@ build:; @cd src; $(MAKE) \
                  FE="$(FE)" \
                  aspic
 
-clean:; cd src; $(MAKE) clean
+clean:
+		$(MAKE) -C src clean
 
-distclean:;     rm Makefile config.cache config.log config.status; \
-                cd src; $(MAKE) clean
+distclean: clean
+		$(RM) Makefile config.cache config.log config.status
 
 test:           build
 		cd testing; ./RunTests


### PR DESCRIPTION
Hi @PhilipHazel,

I opened a pull request with this change:
#4 

This updates the clean target to use $(MAKE) -C src clean instead of changing directories manually.

The distclean target now depends on clean before removing files generated by configure.

Note: The original patch also removed some generated documentation files (doc/pic*.eps, doc/aspic.xml and doc/aspic.ps). After reviewing the upstream build process, I did not include that part because those files are not regenerated by the normal build target.

Thanks.